### PR TITLE
Add .restyled.yaml

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -1,0 +1,2 @@
+restylers:
+  - google-java-format


### PR DESCRIPTION
The [google-java-format Restyler](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#user-content-google-java-format) must be explicitly enabled. Currently it defaults to the [clang-format Restyler](https://github.com/restyled-io/restyled.io/wiki/Available-Restylers#user-content-clang-format) for `.java` files.

See https://github.com/restyled-io/restyled.io/wiki/Configuration-Reference on configuration information.