### PR TITLE
Set Renovate stabilityDays for com.fasterxml.jackson:jackson-bom to 1

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,8 +22,10 @@
       ],
     },
     {
-      // Jackson creates releases before publishing to Maven Central.
-      // Workaround: Delay PR creation so that build doesn't fail
+      /*
+         Jackson creates releases before publishing to Maven Central.
+         Workaround: Delay PR creation so that build doesn't fail
+      */
       packageNames: [
         "com.fasterxml.jackson:jackson-bom",
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,5 +21,13 @@
         ":warning: README.md must be updated manually",
       ],
     },
+    {
+      // Jackson creates releases before publishing to Maven Central.
+      // Workaround: Delay PR creation so that build doesn't fail
+      packageNames: [
+        "com.fasterxml.jackson:jackson-bom",
+      ],
+      stabilityDays: 1,
+    },
   ],
 }


### PR DESCRIPTION
Jackson creates releases before publishing to Maven Central.
This PR delays the PR creation so that the build doesn't fail.